### PR TITLE
Connection redesign

### DIFF
--- a/Todo.md
+++ b/Todo.md
@@ -32,7 +32,7 @@ Below is the current todo list for the project. The legend is as follows:
 					of child connection threads Create a stopConnection
 					function to stop a connection Destructor should look
 					through and call stopConnection on all
-				- -[ ] Remove connection maps, and make vectors again…
+				- -[x] Remove connection maps, and make vectors again…
 				- -[ ] checkAllConnectionsForData Function
 					- -[ ] Interface
 					- -[ ] Implementation

--- a/Todo.md
+++ b/Todo.md
@@ -32,7 +32,35 @@ Below is the current todo list for the project. The legend is as follows:
 					of child connection threads Create a stopConnection
 					function to stop a connection Destructor should look
 					through and call stopConnection on all
-
+					- -[ ] Before we go forward. We need to consider our
+					  design. We shouldn't simply create one thread for every
+					  connection. That will bog us down. So take time to
+					  consider if we can simply do everything in one thread…
+					  We'll need to make a branch for this so we can revert
+					  changes.
+						- -[ ] Create a branch called connection-redesign
+						- -[ ] Consider if we should make more than one
+						  thread, if so, how many for server and clients, and
+						  what will their purpose be?
+						- -[ ] Design a single thread connection
+							- -[ ] We need the following
+								- -[ ] A processHandler for our listening
+								  socket that adds accpected connections to
+								  the MasterTCPConnection's vector of
+								  connections
+								- -[ ] We need a function that check for
+								  incoming information on all sockets and
+								  return a vector of bools.
+								- -[ ] We then need another function to check
+								  on those bools to then call the
+								  processHandler for that connection
+								- -[ ] We need a map for both connections and
+								  processHandler. The key should be a unique
+								  identifier that should exist in both
+								- -[ ] We need to research how to genereat
+								  Unique ID's so that when a new
+								  connection/process Is added that we can
+								  assign it an ID
 	  - -[ ] Send
 	  - -[ ] Recv
 	  - -[ ] sendFrom

--- a/Todo.md
+++ b/Todo.md
@@ -21,7 +21,7 @@ Below is the current todo list for the project. The legend is as follows:
 			everything in one thread… We'll need to make a branch for this
 			so we can revert changes
 			- [x] Create a branch called connection-redesign
-			- [ ] Design a single thread connection
+			- [x] Design a single thread connection
 				- [x] Remove connection maps, and make vectors again…
 				- [x] IPConnection::operator int()
 					- [x] Interface
@@ -33,26 +33,26 @@ Below is the current todo list for the project. The legend is as follows:
 				- [x] checkAllConnectionsForData Function
 					- [x] Interface
 					- [x] Implementation
-				- [ ] getNumConnections - We need this so that we can create
+				- [x] getNumConnections - We need this so that we can create
 				  a successful test case for listenForIncominConnections. The
 				  Server side should test to see if the number of connections
 				  is greater than 0
-				  	- [ ] Interface
-					- [ ] Implementation
-					- [ ] Test
-				- [ ] listenForIncominConnections Function
+				  	- [x] Interface
+					- [x] Implementation
+					- [x] Test
+				- [x] listenForIncominConnections Function
 					- [x] Interface
 					- [x] Implementation
-					- [ ] Test
-				- [ ] Reformat the connectionProcessHandlerFunc to return
+					- [x] Test
+				- [x] Reformat the connectionProcessHandlerFunc to return
 				  a boolean value such that the checkAllConnectionsForData
 				  function will then remove the connection when it returns
 				  false
-				- [ ] removeConnection - For removing previously accepted
+				- [x] removeConnection - For removing previously accepted
 				  connections
 					- [x] Interface
 					- [x] Implementation
-					- [ ] Test
+					- [x] Test
 				- Layout
 					- Basic steps
 						- Listen for a knock at the door or for incoming letters

--- a/Todo.md
+++ b/Todo.md
@@ -6,44 +6,33 @@ Below is the current todo list for the project. The legend is as follows:
 
 
 - [x] Hello World
-- [x] DPServer Class
-- [ ] Server class
-- [ ] Client class
 - [ ] INET Library
-
-	- -[x] Socket
-	- -[x] ServiceAddress
-	- -[x] IPConnection
-	- -[ ] TCPConnection
-	- -[ ] UDPConnection
-	- -[ ] MasterTCPConnection
-		- -[x] Accept
-		- -[x] Connect
-		- -[ ] Before we go forward. We need to consider our design. We
+	- [x] Socket
+	- [x] ServiceAddress
+	- [x] IPConnection
+	- [ ] TCPConnection
+	- [ ] UDPConnection
+	- [ ] MasterTCPConnection
+		- [x] Accept
+		- [x] Connect
+		- [ ] Before we go forward. We need to consider our design. We
 			shouldn't simply create one thread for every connection. That
 			will bog us down. So take time to consider if we can simply do
 			everything in one thread… We'll need to make a branch for this
 			so we can revert changes
-			- -[x] Create a branch called connection-redesign
-			- -[ ] Consider if we should make more than one thread, if so, how
-				many for server and clients, and what will their purpose be?
-				- -[ ] Design a single thread connection
-				- [ ] removeConnection - For removing previously accepted
-				  connections
-					- [ ] Interface
-					- [ ] Implementation
-					- [ ] Test
-				- -[x] Remove connection maps, and make vectors again…
-				- -[x] IPConnection::operator int()
-					- -[x] Interface
-					- -[x] Implementation
-					- -[x] Test
-				- -[x] getLargestSocket
-					- -[x] Interface
-					- -[x] Implementation
-				- -[x] checkAllConnectionsForData Function
-					- -[x] Interface
-					- -[x] Implementation
+			- [x] Create a branch called connection-redesign
+			- [ ] Design a single thread connection
+				- [x] Remove connection maps, and make vectors again…
+				- [x] IPConnection::operator int()
+					- [x] Interface
+					- [x] Implementation
+					- [x] Test
+				- [x] getLargestSocket
+					- [x] Interface
+					- [x] Implementation
+				- [x] checkAllConnectionsForData Function
+					- [x] Interface
+					- [x] Implementation
 				- [ ] getNumConnections - We need this so that we can create
 				  a successful test case for listenForIncominConnections. The
 				  Server side should test to see if the number of connections
@@ -51,10 +40,19 @@ Below is the current todo list for the project. The legend is as follows:
 				  	- [ ] Interface
 					- [ ] Implementation
 					- [ ] Test
-				- -[ ] listenForIncominConnections Function
-					- -[x] Interface
-					- -[x] Implementation
-					- -[ ] Test
+				- [ ] listenForIncominConnections Function
+					- [x] Interface
+					- [x] Implementation
+					- [ ] Test
+				- [ ] Reformat the connectionProcessHandlerFunc to return
+				  a boolean value such that the checkAllConnectionsForData
+				  function will then remove the connection when it returns
+				  false
+				- [ ] removeConnection - For removing previously accepted
+				  connections
+					- [x] Interface
+					- [x] Implementation
+					- [ ] Test
 				- Layout
 					- Basic steps
 						- Listen for a knock at the door or for incoming letters
@@ -65,7 +63,10 @@ Below is the current todo list for the project. The legend is as follows:
 						- If it's a letter
 							- Process the message
 
-	  - -[ ] Send
-	  - -[ ] Recv
-	  - -[ ] sendFrom
-	  - -[ ] recvFrom
+	  - [ ] Send
+	  - [ ] Recv
+	  - [ ] sendFrom
+	  - [ ] recvFrom
+- [ ] DPServer Class
+- [ ] Server class
+- [ ] Client class

--- a/Todo.md
+++ b/Todo.md
@@ -4,35 +4,36 @@ Below is the current todo list for the project. The legend is as follows:
 
 ----------------------------
 
-[x] - Hello World
-[x] - DPServer Class
-[ ] - Server class
-[ ] - Client class
 
-[ ] - INET Library
-	[ ] - Socket
-	[ ] - ServiceAddress
-	[ ] - IPConnection
-	[ ] - TCPConnection
-	[ ] - UDPConnection
-	[ ] - MasterTCPConnection
-		[ ] - Accept
-		[ ] - Connect
-		[ ] - Before we go forward. We need to consider our design. We
+- [x] Hello World
+- [x] DPServer Class
+- [ ] Server class
+- [ ] Client class
+- [ ] INET Library
+
+	- -[ ] Socket
+	- -[ ] ServiceAddress
+	- -[ ] IPConnection
+	- -[ ] TCPConnection
+	- -[ ] UDPConnection
+	- -[ ] MasterTCPConnection
+		- -[ ] Accept
+		- -[ ] Connect
+		- -[ ] Before we go forward. We need to consider our design. We
 			shouldn't simply create one thread for every connection. That
 			will bog us down. So take time to consider if we can simply do
 			everything in one thread… We'll need to make a branch for this
 			so we can revert changes
-			[ ] - Create a branch called connection-redesign
-			[ ] - Consider if we should make more than one thread, if so, how
+			- -[ ] Create a branch called connection-redesign
+			- -[ ] Consider if we should make more than one thread, if so, how
 				many for server and clients, and what will their purpose be?
-				[ ] - Design a single thread connection
-				[ ] - MasterTCPConnection destructor needs to handle shutdown
+				- -[ ] Design a single thread connection
+				- -[ ] MasterTCPConnection destructor needs to handle shutdown
 					of child connection threads Create a stopConnection
 					function to stop a connection Destructor should look
 					through and call stopConnection on all
 
-	  [ ] - Send
-	  [ ] - Recv
-	  [ ] - sendFrom
-	  [ ] - recvFrom
+	  - -[ ] Send
+	  - -[ ] Recv
+	  - -[ ] sendFrom
+	  - -[ ] recvFrom

--- a/Todo.md
+++ b/Todo.md
@@ -37,9 +37,9 @@ Below is the current todo list for the project. The legend is as follows:
 					- -[x] Interface
 					- -[x] Implementation
 					- -[x] Test
-				- -[ ] getLargestSocket
+				- -[x] getLargestSocket
 					- -[x] Interface
-					- -[ ] Implementation
+					- -[x] Implementation
 				- -[ ] checkAllConnectionsForData Function
 					- -[x] Interface
 					- -[ ] Implementation

--- a/Todo.md
+++ b/Todo.md
@@ -33,10 +33,10 @@ Below is the current todo list for the project. The legend is as follows:
 					function to stop a connection Destructor should look
 					through and call stopConnection on all
 				- -[x] Remove connection maps, and make vectors again…
-				- -[ ] IPConnection::operator int()
+				- -[x] IPConnection::operator int()
 					- -[x] Interface
 					- -[x] Implementation
-					- -[ ] Test
+					- -[x] Test
 				- -[ ] getLargestSocket
 					- -[x] Interface
 					- -[ ] Implementation

--- a/Todo.md
+++ b/Todo.md
@@ -33,14 +33,16 @@ Below is the current todo list for the project. The legend is as follows:
 					function to stop a connection Destructor should look
 					through and call stopConnection on all
 				- -[x] Remove connection maps, and make vectors again…
-				- -[ ] getLargestSocket
+				- -[ ] IPConnection::operator int()
 					- -[ ] Interface
 					- -[ ] Implementation
 					- -[ ] Test
+				- -[ ] getLargestSocket
+					- -[x] Interface
+					- -[ ] Implementation
 				- -[ ] checkAllConnectionsForData Function
 					- -[x] Interface
 					- -[ ] Implementation
-					- -[ ] Test
 				- -[ ] listenForIncominConnections Function
 					- -[ ] Interface
 					- -[ ] Implementation

--- a/Todo.md
+++ b/Todo.md
@@ -28,10 +28,11 @@ Below is the current todo list for the project. The legend is as follows:
 			- -[ ] Consider if we should make more than one thread, if so, how
 				many for server and clients, and what will their purpose be?
 				- -[ ] Design a single thread connection
-				- -[ ] MasterTCPConnection destructor needs to handle shutdown
-					of child connection threads Create a stopConnection
-					function to stop a connection Destructor should look
-					through and call stopConnection on all
+				- [ ] removeConnection - For removing previously accepted
+				  connections
+					- [ ] Interface
+					- [ ] Implementation
+					- [ ] Test
 				- -[x] Remove connection maps, and make vectors again…
 				- -[x] IPConnection::operator int()
 					- -[x] Interface

--- a/Todo.md
+++ b/Todo.md
@@ -43,9 +43,16 @@ Below is the current todo list for the project. The legend is as follows:
 				- -[x] checkAllConnectionsForData Function
 					- -[x] Interface
 					- -[x] Implementation
+				- [ ] getNumConnections - We need this so that we can create
+				  a successful test case for listenForIncominConnections. The
+				  Server side should test to see if the number of connections
+				  is greater than 0
+				  	- [ ] Interface
+					- [ ] Implementation
+					- [ ] Test
 				- -[ ] listenForIncominConnections Function
 					- -[x] Interface
-					- -[ ] Implementation
+					- -[x] Implementation
 					- -[ ] Test
 				- Layout
 					- Basic steps

--- a/Todo.md
+++ b/Todo.md
@@ -2,13 +2,37 @@
 
 Below is the current todo list for the project. The legend is as follows:
 
-- [ ] - Uncomplete
-- [√] - Complete
-- [+] - In progress
-
 ----------------------------
 
-[√] - Hello World
-[√] - DPServer Class
+[x] - Hello World
+[x] - DPServer Class
 [ ] - Server class
 [ ] - Client class
+
+[ ] - INET Library
+	[ ] - Socket
+	[ ] - ServiceAddress
+	[ ] - IPConnection
+	[ ] - TCPConnection
+	[ ] - UDPConnection
+	[ ] - MasterTCPConnection
+		[ ] - Accept
+		[ ] - Connect
+		[ ] - Before we go forward. We need to consider our design. We
+			shouldn't simply create one thread for every connection. That
+			will bog us down. So take time to consider if we can simply do
+			everything in one thread… We'll need to make a branch for this
+			so we can revert changes
+			[ ] - Create a branch called connection-redesign
+			[ ] - Consider if we should make more than one thread, if so, how
+				many for server and clients, and what will their purpose be?
+				[ ] - Design a single thread connection
+				[ ] - MasterTCPConnection destructor needs to handle shutdown
+					of child connection threads Create a stopConnection
+					function to stop a connection Destructor should look
+					through and call stopConnection on all
+
+	  [ ] - Send
+	  [ ] - Recv
+	  [ ] - sendFrom
+	  [ ] - recvFrom

--- a/Todo.md
+++ b/Todo.md
@@ -34,7 +34,7 @@ Below is the current todo list for the project. The legend is as follows:
 					through and call stopConnection on all
 				- -[x] Remove connection maps, and make vectors again…
 				- -[ ] IPConnection::operator int()
-					- -[ ] Interface
+					- -[x] Interface
 					- -[ ] Implementation
 					- -[ ] Test
 				- -[ ] getLargestSocket

--- a/Todo.md
+++ b/Todo.md
@@ -11,20 +11,20 @@ Below is the current todo list for the project. The legend is as follows:
 - [ ] Client class
 - [ ] INET Library
 
-	- -[ ] Socket
-	- -[ ] ServiceAddress
-	- -[ ] IPConnection
+	- -[x] Socket
+	- -[x] ServiceAddress
+	- -[x] IPConnection
 	- -[ ] TCPConnection
 	- -[ ] UDPConnection
 	- -[ ] MasterTCPConnection
-		- -[ ] Accept
-		- -[ ] Connect
+		- -[x] Accept
+		- -[x] Connect
 		- -[ ] Before we go forward. We need to consider our design. We
 			shouldn't simply create one thread for every connection. That
 			will bog us down. So take time to consider if we can simply do
 			everything in one thread… We'll need to make a branch for this
 			so we can revert changes
-			- -[ ] Create a branch called connection-redesign
+			- -[x] Create a branch called connection-redesign
 			- -[ ] Consider if we should make more than one thread, if so, how
 				many for server and clients, and what will their purpose be?
 				- -[ ] Design a single thread connection
@@ -32,40 +32,25 @@ Below is the current todo list for the project. The legend is as follows:
 					of child connection threads Create a stopConnection
 					function to stop a connection Destructor should look
 					through and call stopConnection on all
-					- -[ ] Before we go forward. We need to consider our
-					  design. We shouldn't simply create one thread for every
-					  connection. That will bog us down. So take time to
-					  consider if we can simply do everything in one thread…
-					  We'll need to make a branch for this so we can revert
-					  changes.
-						- -[ ] Create a branch called connection-redesign
-						- -[ ] Consider if we should make more than one
-						  thread, if so, how many for server and clients, and
-						  what will their purpose be?
-						- -[ ] Design a single thread connection
-							- -[ ] We need the following
-								- -[ ] A processHandler for our listening
-								  socket that adds accpected connections to
-								  the MasterTCPConnection's vector of
-								  connections
-								- -[ ] We need a function that check for
-								  incoming information on all sockets and
-								  return a vector of bools.
-								- -[ ] We then need another function to check
-								  on those bools to then call the
-								  processHandler for that connection
-								- -[ ] We need a map for both connections and
-								  processHandler. The key should be a unique
-								  identifier that should exist in both
-								- -[x] We need to research how to genereat
-								  Unique ID's so that when a new
-								  connection/process Is added that we can
-								  assign it an ID
-									- Because the no two connections share the
-									  same file descriptor, we can use the
-									  number of the socket as the ID to which
-									  the connection and the processHandler
-									  are mapped
+				- -[ ] Remove connection maps, and make vectors again…
+				- -[ ] checkAllConnectionsForData Function
+					- -[ ] Interface
+					- -[ ] Implementation
+					- -[ ] Test
+				- -[ ] listenForIncominConnections Function
+					- -[ ] Interface
+					- -[ ] Implementation
+					- -[ ] Test
+				- Layout
+					- Basic steps
+						- Listen for a knock at the door or for incoming letters
+						- If It's a knock at the door
+							- Open the door when some one is there
+							- Decide whether to let them in
+							- Once they're in add them to the list of connections
+						- If it's a letter
+							- Process the message
+
 	  - -[ ] Send
 	  - -[ ] Recv
 	  - -[ ] sendFrom

--- a/Todo.md
+++ b/Todo.md
@@ -35,7 +35,7 @@ Below is the current todo list for the project. The legend is as follows:
 				- -[x] Remove connection maps, and make vectors again…
 				- -[ ] IPConnection::operator int()
 					- -[x] Interface
-					- -[ ] Implementation
+					- -[x] Implementation
 					- -[ ] Test
 				- -[ ] getLargestSocket
 					- -[x] Interface

--- a/Todo.md
+++ b/Todo.md
@@ -57,10 +57,15 @@ Below is the current todo list for the project. The legend is as follows:
 								- -[ ] We need a map for both connections and
 								  processHandler. The key should be a unique
 								  identifier that should exist in both
-								- -[ ] We need to research how to genereat
+								- -[x] We need to research how to genereat
 								  Unique ID's so that when a new
 								  connection/process Is added that we can
 								  assign it an ID
+									- Because the no two connections share the
+									  same file descriptor, we can use the
+									  number of the socket as the ID to which
+									  the connection and the processHandler
+									  are mapped
 	  - -[ ] Send
 	  - -[ ] Recv
 	  - -[ ] sendFrom

--- a/Todo.md
+++ b/Todo.md
@@ -33,8 +33,12 @@ Below is the current todo list for the project. The legend is as follows:
 					function to stop a connection Destructor should look
 					through and call stopConnection on all
 				- -[x] Remove connection maps, and make vectors again…
-				- -[ ] checkAllConnectionsForData Function
+				- -[ ] getLargestSocket
 					- -[ ] Interface
+					- -[ ] Implementation
+					- -[ ] Test
+				- -[ ] checkAllConnectionsForData Function
+					- -[x] Interface
 					- -[ ] Implementation
 					- -[ ] Test
 				- -[ ] listenForIncominConnections Function

--- a/Todo.md
+++ b/Todo.md
@@ -40,11 +40,11 @@ Below is the current todo list for the project. The legend is as follows:
 				- -[x] getLargestSocket
 					- -[x] Interface
 					- -[x] Implementation
-				- -[ ] checkAllConnectionsForData Function
+				- -[x] checkAllConnectionsForData Function
 					- -[x] Interface
-					- -[ ] Implementation
+					- -[x] Implementation
 				- -[ ] listenForIncominConnections Function
-					- -[ ] Interface
+					- -[x] Interface
 					- -[ ] Implementation
 					- -[ ] Test
 				- Layout

--- a/include/inet/IPConnection.hpp
+++ b/include/inet/IPConnection.hpp
@@ -25,6 +25,8 @@ namespace inet
 			int connect(std::string addressString);
 			virtual bool send(void* data) const = 0;
 
+			operator int const() const;
+
 		protected:
 			mutable std::mutex socket_mutex;
 			mutable std::mutex srcAddr_mutex;

--- a/include/inet/MasterTCPConnection.hpp
+++ b/include/inet/MasterTCPConnection.hpp
@@ -17,6 +17,7 @@ namespace inet
 			~MasterTCPConnection(void);
 			int getNumConnections(void) const;
 			void acceptConnection(std::shared_ptr<TCPConnection>& newTCPConnection);
+			void removeConnection(std::shared_ptr<TCPConnection>& conn);
 			void listenForIncomingConnections(newConnectionAcceptHandlerFunc const& ncaHandler, connectionProcessHandlerFunc const& cpHandler);
 			void stopListening(void);
 			std::shared_ptr<TCPConnection> const answerIncomingConnection(void) const;

--- a/include/inet/MasterTCPConnection.hpp
+++ b/include/inet/MasterTCPConnection.hpp
@@ -11,7 +11,7 @@ namespace inet
 	{
 		public:
 			typedef std::function<bool (std::shared_ptr<TCPConnection>&)> newConnectionAcceptHandlerFunc;
-			typedef std::function<void (std::shared_ptr<TCPConnection>&)> connectionProcessHandlerFunc;
+			typedef std::function<bool (std::shared_ptr<TCPConnection>&)> connectionProcessHandlerFunc;
 			
 			MasterTCPConnection(void);
 			~MasterTCPConnection(void);

--- a/include/inet/MasterTCPConnection.hpp
+++ b/include/inet/MasterTCPConnection.hpp
@@ -2,7 +2,7 @@
 #ifndef INET_MASTER_TCP_CONNECTION_HPP
 #define INET_MASTER_TCP_CONNECTION_HPP
 
-#include <vector>
+#include <map>
 #include "inet/TCPConnection.hpp"
 
 namespace inet
@@ -23,8 +23,10 @@ namespace inet
 		private:
 			std::thread listeningThread;
 			std::mutex listeningThread_mutex;
-			std::vector<std::shared_ptr<TCPConnection>> TCPConnections;
+			std::map<unsigned int, std::shared_ptr<TCPConnection>> TCPConnections;
 			std::mutex tcpc_mutex;
+			std::map<unsigned int, std::shared_ptr<connectionProcessHandlerFunc>> TCPProcesses;
+			std::mutex tcpp_mutex;
 			bool listening = false;
 			mutable std::mutex listening_mutex;
 			newConnectionAcceptHandlerFunc newConnectionAcceptHandler;

--- a/include/inet/MasterTCPConnection.hpp
+++ b/include/inet/MasterTCPConnection.hpp
@@ -2,7 +2,7 @@
 #ifndef INET_MASTER_TCP_CONNECTION_HPP
 #define INET_MASTER_TCP_CONNECTION_HPP
 
-#include <map>
+#include <vector>
 #include "inet/TCPConnection.hpp"
 
 namespace inet
@@ -23,10 +23,8 @@ namespace inet
 		private:
 			std::thread listeningThread;
 			std::mutex listeningThread_mutex;
-			std::map<unsigned int, std::shared_ptr<TCPConnection>> TCPConnections;
+			std::vector<std::shared_ptr<TCPConnection>> TCPConnections;
 			std::mutex tcpc_mutex;
-			std::map<unsigned int, std::shared_ptr<connectionProcessHandlerFunc>> TCPProcesses;
-			std::mutex tcpp_mutex;
 			bool listening = false;
 			mutable std::mutex listening_mutex;
 			newConnectionAcceptHandlerFunc newConnectionAcceptHandler;

--- a/include/inet/MasterTCPConnection.hpp
+++ b/include/inet/MasterTCPConnection.hpp
@@ -15,11 +15,12 @@ namespace inet
 			
 			MasterTCPConnection(void);
 			~MasterTCPConnection(void);
+			int getNumConnections(void) const;
+			void acceptConnection(std::shared_ptr<TCPConnection>& newTCPConnection);
 			void listenForIncomingConnections(newConnectionAcceptHandlerFunc const& ncaHandler, connectionProcessHandlerFunc const& cpHandler);
 			void stopListening(void);
 			std::shared_ptr<TCPConnection> const answerIncomingConnection(void) const;
-			void acceptConnection(std::shared_ptr<TCPConnection>& newTCPConnection);
-			void shutdownConnection(std::shared_ptr<TCPConnection>& TCPConnection);
+
 		private:
 			std::thread listeningThread;
 			std::mutex listeningThread_mutex;

--- a/include/inet/MasterTCPConnection.hpp
+++ b/include/inet/MasterTCPConnection.hpp
@@ -34,7 +34,7 @@ namespace inet
 			bool isListeningFinished(void) const;
 			void setListeningState(bool state);
 			void beginListening();
-			void checkAllConnectionsForData(void) const;
+			bool checkAllConnectionsForData(double timeout);
 			int getLargestSocket(void) const;
 	};
 }

--- a/include/inet/MasterTCPConnection.hpp
+++ b/include/inet/MasterTCPConnection.hpp
@@ -23,8 +23,6 @@ namespace inet
 		private:
 			std::thread listeningThread;
 			std::mutex listeningThread_mutex;
-			std::vector<std::thread> connectionHandlerThreads;
-			std::mutex chThreads_mutex;
 			std::vector<std::shared_ptr<TCPConnection>> TCPConnections;
 			std::mutex tcpc_mutex;
 			bool listening = false;

--- a/include/inet/MasterTCPConnection.hpp
+++ b/include/inet/MasterTCPConnection.hpp
@@ -34,7 +34,8 @@ namespace inet
 			bool isListeningFinished(void) const;
 			void setListeningState(bool state);
 			void beginListening();
-			void checkAllConnectionsForData(void);
+			void checkAllConnectionsForData(void) const;
+			unsigned int getLargestSocket(void) const;
 	};
 }
 

--- a/include/inet/MasterTCPConnection.hpp
+++ b/include/inet/MasterTCPConnection.hpp
@@ -34,6 +34,7 @@ namespace inet
 			bool isListeningFinished(void) const;
 			void setListeningState(bool state);
 			void beginListening();
+			void checkAllConnectionsForData(void);
 	};
 }
 

--- a/include/inet/MasterTCPConnection.hpp
+++ b/include/inet/MasterTCPConnection.hpp
@@ -35,7 +35,7 @@ namespace inet
 			void setListeningState(bool state);
 			void beginListening();
 			void checkAllConnectionsForData(void) const;
-			unsigned int getLargestSocket(void) const;
+			int getLargestSocket(void) const;
 	};
 }
 

--- a/src/inet/IPConnection.cpp
+++ b/src/inet/IPConnection.cpp
@@ -101,6 +101,11 @@ namespace inet
 		return 0;
 	}
 
+	IPConnection::operator int const() const
+	{
+		return *this->socket.get();
+	}
+
 	void IPConnection::updateSrcAddr(void)
 	{
 		std::lock_guard<std::mutex> addr_lock {this->srcAddr_mutex};

--- a/src/inet/MasterTCPConnection.cpp
+++ b/src/inet/MasterTCPConnection.cpp
@@ -129,7 +129,7 @@ namespace inet
 			throw "MasterTCPConnection::checkAllConnectionsForData - failed to select!";
 		}
 
-		if(FD_ISSET(masterSocket, &fdSet) == true)
+		if(FD_ISSET(masterSocket, &fdSet))
 		{
 			result = true;
 			std::shared_ptr<TCPConnection> newConnection = this->answerIncomingConnection();
@@ -143,7 +143,7 @@ namespace inet
 		tcpc_lock.lock();
 		for(std::shared_ptr<TCPConnection> pCurConn : this->TCPConnections)
 		{
-			if(FD_ISSET(*pCurConn, &fdSet) == true)
+			if(FD_ISSET(*pCurConn, &fdSet))
 			{
 				result = true;
 				this->connectionProcessHandler(pCurConn);

--- a/src/inet/MasterTCPConnection.cpp
+++ b/src/inet/MasterTCPConnection.cpp
@@ -96,4 +96,13 @@ namespace inet
 			}
 		}
 	}
+
+	void MasterTCPConnection::checkAllConnectionsForData(void)
+	{
+		fd_set fdSet;
+		struct timeval tv;
+		int largestFD;
+
+		// Get largest socket file descriptor
+	}
 }

--- a/src/inet/MasterTCPConnection.cpp
+++ b/src/inet/MasterTCPConnection.cpp
@@ -33,6 +33,22 @@ namespace inet
 		}
 	}
 
+	void MasterTCPConnection::removeConnection(std::shared_ptr<TCPConnection>& conn)
+	{
+		std::lock_guard<std::mutex> lock {this->tcpc_mutex};
+		for(std::vector<std::shared_ptr<TCPConnection>>::iterator it = this->TCPConnections.begin(); it != this->TCPConnections.end() ; )
+		{
+			if(*it == conn)
+			{
+				it = this->TCPConnections.erase(it);
+			}
+			else
+			{
+				it++;
+			}
+		}
+	}
+
 	void MasterTCPConnection::listenForIncomingConnections(MasterTCPConnection::newConnectionAcceptHandlerFunc const& ncah, MasterTCPConnection::connectionProcessHandlerFunc const& cph)
 	{
 		if(this->isListening()) return;

--- a/src/inet/MasterTCPConnection.cpp
+++ b/src/inet/MasterTCPConnection.cpp
@@ -64,8 +64,8 @@ namespace inet
 
 		// Start the connection process thread
 		{
-			std::lock_guard<std::mutex> lock {this->chThreads_mutex};
-			this->connectionHandlerThreads.emplace_back(std::thread([this, &newTCPConnection]{this->connectionProcessHandler(newTCPConnection);}));
+			//std::lock_guard<std::mutex> lock {this->chThreads_mutex};
+			//this->connectionHandlerThreads.emplace_back(std::thread([this, &newTCPConnection]{this->connectionProcessHandler(newTCPConnection);}));
 		}
 	}
 

--- a/src/inet/MasterTCPConnection.cpp
+++ b/src/inet/MasterTCPConnection.cpp
@@ -102,19 +102,18 @@ namespace inet
 		fd_set fdSet;
 		struct timeval tv;
 		int largestFD;
-
-		// Get largest socket file descriptor
 	}
 
-	unsigned int MasterTCPConnection::getLargestSocket(void) const
+	int MasterTCPConnection::getLargestSocket(void) const
 	{
 		int currentSocket = *this->socket.get();
-		unsigned int result = static_cast<unsigned int>(currentSocket);
+		int result = currentSocket;
 
 		for(std::shared_ptr<TCPConnection> pCurConn : this->TCPConnections)
 		{
-			//currentSocket = pCurConn->socket;
-			// static_cast<int>(pCurConn) should return the socket file descriptor
+			 currentSocket = *pCurConn;
+			 if(currentSocket > result)
+				 result = currentSocket;
 		}
 
 		return result;

--- a/src/inet/MasterTCPConnection.cpp
+++ b/src/inet/MasterTCPConnection.cpp
@@ -58,8 +58,8 @@ namespace inet
 	{
 		// Add the connection to our list of connections
 		{
-			std::lock_guard<std::mutex> lock {this->tcpc_mutex};
-			this->TCPConnections.emplace_back(newTCPConnection);
+			//std::lock_guard<std::mutex> lock {this->tcpc_mutex};
+			//this->TCPConnections.emplace_back(newTCPConnection);
 		}
 
 		// Start the connection process thread

--- a/src/inet/MasterTCPConnection.cpp
+++ b/src/inet/MasterTCPConnection.cpp
@@ -39,8 +39,6 @@ namespace inet
 		else
 		{
 			this->setListeningState(false);
-			//std::unique_lock<std::mutex> lock {this->listeningFinished_mutex};
-			//this->listeningFinished_cv.wait(lock, [=]{return this->isListeningFinished();});
 			this->listeningThread.join();
 		}
 	}
@@ -64,14 +62,8 @@ namespace inet
 	{
 		// Add the connection to our list of connections
 		{
-			//std::lock_guard<std::mutex> lock {this->tcpc_mutex};
-			//this->TCPConnections.emplace_back(newTCPConnection);
-		}
-
-		// Start the connection process thread
-		{
-			//std::lock_guard<std::mutex> lock {this->chThreads_mutex};
-			//this->connectionHandlerThreads.emplace_back(std::thread([this, &newTCPConnection]{this->connectionProcessHandler(newTCPConnection);}));
+			std::lock_guard<std::mutex> lock {this->tcpc_mutex};
+			this->TCPConnections.emplace_back(newTCPConnection);
 		}
 	}
 
@@ -92,8 +84,7 @@ namespace inet
 		// Check for a new connection every 5 seconds
 		while(this->isListening())
 		{
-			if(this->isDataReady(5.0)) {
-					}
+			this->checkAllConnectionsForData(5.0);
 		}
 	}
 

--- a/src/inet/MasterTCPConnection.cpp
+++ b/src/inet/MasterTCPConnection.cpp
@@ -1,4 +1,10 @@
 #include <iostream>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/time.h>
 #include "inet/MasterTCPConnection.hpp"
 
 namespace inet
@@ -87,26 +93,68 @@ namespace inet
 		while(this->isListening())
 		{
 			if(this->isDataReady(5.0)) {
-				std::shared_ptr<TCPConnection> newConnection = this->answerIncomingConnection();
-				bool acceptConnection = this->newConnectionAcceptHandler(newConnection);
-				if(acceptConnection)
-				{
-					this->acceptConnection(newConnection);
-				}
-			}
+					}
 		}
 	}
 
-	void MasterTCPConnection::checkAllConnectionsForData(void) const
+	bool MasterTCPConnection::checkAllConnectionsForData(double timeout)
 	{
 		fd_set fdSet;
 		struct timeval tv;
-		int largestFD;
+		int largestFD = this->getLargestSocket();
+		bool result = false;
+
+		// Clear the set
+		FD_ZERO(&fdSet);
+
+		// Add all sockets to the set
+		FD_SET(*this, &fdSet);
+		for(std::shared_ptr<TCPConnection> pCurConn : this->TCPConnections)
+		{
+			FD_SET(*pCurConn, &fdSet);
+		}
+
+		// Set timeout
+		int seconds = static_cast<int>(floor(timeout));
+		double remainder = timeout - seconds;
+		double remainder_us = remainder * 1e6;
+		int microseconds = static_cast<int>(floor(remainder_us));
+
+		tv.tv_sec = seconds;
+		tv.tv_usec = microseconds;
+
+		int retval = select(largestFD+1, &fdSet, nullptr, nullptr, &tv);
+
+		if(retval == -1) {
+			throw "MasterTCPConnection::checkAllConnectionsForData - failed to select!";
+		}
+
+		if(FD_ISSET(*this, &fdSet) == true)
+		{
+			result = true;
+			std::shared_ptr<TCPConnection> newConnection = this->answerIncomingConnection();
+			bool acceptConnection = this->newConnectionAcceptHandler(newConnection);
+			if(acceptConnection)
+			{
+				this->acceptConnection(newConnection);
+			}
+		}
+
+		for(std::shared_ptr<TCPConnection> pCurConn : this->TCPConnections)
+		{
+			if(FD_ISSET(*pCurConn, &fdSet) == true)
+			{
+				result = true;
+				this->connectionProcessHandler(pCurConn);
+			}
+		}
+
+		return result;
 	}
 
 	int MasterTCPConnection::getLargestSocket(void) const
 	{
-		int currentSocket = *this->socket.get();
+		int currentSocket = *this;
 		int result = currentSocket;
 
 		for(std::shared_ptr<TCPConnection> pCurConn : this->TCPConnections)

--- a/src/inet/MasterTCPConnection.cpp
+++ b/src/inet/MasterTCPConnection.cpp
@@ -157,13 +157,17 @@ namespace inet
 		}
 
 		tcpc_lock.lock();
-		for(std::shared_ptr<TCPConnection> pCurConn : this->TCPConnections)
+		for(std::vector<std::shared_ptr<TCPConnection>>::iterator it = this->TCPConnections.begin(); it != this->TCPConnections.end() ; )
 		{
+			std::shared_ptr<TCPConnection> pCurConn = *it;
 			if(FD_ISSET(*pCurConn, &fdSet))
 			{
 				result = true;
-				this->connectionProcessHandler(pCurConn);
+				bool keepConn = this->connectionProcessHandler(pCurConn);
+				if(!keepConn) it = this->TCPConnections.erase(it);
+				else ++it;
 			}
+			else ++it;
 		}
 		tcpc_lock.unlock();
 

--- a/src/inet/MasterTCPConnection.cpp
+++ b/src/inet/MasterTCPConnection.cpp
@@ -97,12 +97,26 @@ namespace inet
 		}
 	}
 
-	void MasterTCPConnection::checkAllConnectionsForData(void)
+	void MasterTCPConnection::checkAllConnectionsForData(void) const
 	{
 		fd_set fdSet;
 		struct timeval tv;
 		int largestFD;
 
 		// Get largest socket file descriptor
+	}
+
+	unsigned int MasterTCPConnection::getLargestSocket(void) const
+	{
+		int currentSocket = *this->socket.get();
+		unsigned int result = static_cast<unsigned int>(currentSocket);
+
+		for(std::shared_ptr<TCPConnection> pCurConn : this->TCPConnections)
+		{
+			//currentSocket = pCurConn->socket;
+			// static_cast<int>(pCurConn) should return the socket file descriptor
+		}
+
+		return result;
 	}
 }

--- a/tests/src/inet/MasterTCPConnection_test.cpp
+++ b/tests/src/inet/MasterTCPConnection_test.cpp
@@ -28,13 +28,15 @@ TEST(MasterTCPConnectionTest, listenForIncomingConnections)
 	// Define the accept Handler
 	inet::MasterTCPConnection::newConnectionAcceptHandlerFunc ncah = [](std::shared_ptr<inet::TCPConnection>& nc) -> bool {
 		std::cout << "new connection!" << std::endl;
+		if(nc) {}
 		return true;
 	};
 	
 	// Define the process Handler
-	inet::MasterTCPConnection::connectionProcessHandlerFunc cph = [](std::shared_ptr<inet::TCPConnection>& nc){
+	inet::MasterTCPConnection::connectionProcessHandlerFunc cph = [](std::shared_ptr<inet::TCPConnection>& nc) -> bool {
 		std::cout << "Process conenction: " << static_cast<int>(*nc) << std::endl;
 		if(nc){}
+		return false;
 	};
 
 	// Create a new MasterTCPConnection
@@ -107,7 +109,7 @@ TEST(MasterTCPConnectionTest, listenForIncomingConnections)
 		cv.wait(lk, [&]{return step == "Server Done";});
 	}};
 	
-	serverThread.join();
 	clientThread.join();
+	serverThread.join();
 }
 

--- a/tests/src/inet/MasterTCPConnection_test.cpp
+++ b/tests/src/inet/MasterTCPConnection_test.cpp
@@ -17,7 +17,7 @@ TEST(MasterTCPConnectionTest, listenForIncomingConnections)
 	// Define the accept Handler
 	inet::MasterTCPConnection::newConnectionAcceptHandlerFunc ncah = [](std::shared_ptr<inet::TCPConnection>& nc) -> bool {
 		std::cout << "new connection!" << std::endl;
-		return false;
+		return true;
 	};
 	
 	// Define the process Handler

--- a/tests/src/inet/MasterTCPConnection_test.cpp
+++ b/tests/src/inet/MasterTCPConnection_test.cpp
@@ -33,7 +33,7 @@ TEST(MasterTCPConnectionTest, listenForIncomingConnections)
 	
 	// Define the process Handler
 	inet::MasterTCPConnection::connectionProcessHandlerFunc cph = [](std::shared_ptr<inet::TCPConnection>& nc){
-		std::cout << "Process new conenction!" << std::endl;
+		std::cout << "Process conenction: " << static_cast<int>(*nc) << std::endl;
 		if(nc){}
 	};
 
@@ -77,7 +77,6 @@ TEST(MasterTCPConnectionTest, listenForIncomingConnections)
 
 		ASSERT_EQ(master.getNumConnections(), 1);
 		step = "Server Done";
-		std::cout << step << std::endl;
 
 		lk.unlock();
 		cv.notify_one();
@@ -104,11 +103,11 @@ TEST(MasterTCPConnectionTest, listenForIncomingConnections)
 		lk.unlock();
 		cv.notify_one();
 
-		//lk.lock();
-		//cv.wait(lk, [&]{return step == "Server Done";});
+		lk.lock();
+		cv.wait(lk, [&]{return step == "Server Done";});
 	}};
 	
-	clientThread.join();
 	serverThread.join();
+	clientThread.join();
 }
 

--- a/tests/src/inet/TCPConnection_test.cpp
+++ b/tests/src/inet/TCPConnection_test.cpp
@@ -65,3 +65,10 @@ TEST(TCPConnectionTest, connect)
 	int result = tcpc.connect("192.168.1.1:2300");
 	ASSERT_EQ(result == 61 || result == 60, true);
 }
+
+TEST(TCPConnectionTest, castInt)
+{
+	inet::TCPConnection tcpc;
+	int result = tcpc;
+	ASSERT_NE(result, -1);
+}


### PR DESCRIPTION
Rather than have MasterTCPConnection manage all client connections on separate and individual threads for each client, we'll keep it single threaded using BSD sockets select(2) function. If speed becomes an issue later, we'll build in worker threads and job pools to help relieve hangups when waiting for other connection processes to finish their processes.